### PR TITLE
Fix warning in cups_pre_install.yml

### DIFF
--- a/tasks/cups_pre_install.yml
+++ b/tasks/cups_pre_install.yml
@@ -22,7 +22,7 @@
         repo: "{{cups_openprinting_repo}}"
         state: present
         update_cache: yes
-  when: cups_openprinting_apt_required
+  when: cups_openprinting_apt_required is defined and cups_openprinting_apt_required == True
 
 - name: Update apt cache.
   apt:


### PR DESCRIPTION
Received warning as follows:

```
TASK [HP41.cups : Add OpenPrinting APT Key] *****************************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{cups_ricoh_openprinting_ppds}}

changed: [localhost]

TASK [HP41.cups : Add OpenPrinting Package repo] ************************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{cups_ricoh_openprinting_ppds}}
```

Fixed with this change.